### PR TITLE
iozone 3.506

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,22 @@ FROM alpine as build
 
 RUN apk --update upgrade && \
     apk add --no-cache --virtual=temporary curl gcc make build-base && \
-    curl -o /tmp/iozone.tar http://www.iozone.org/src/current/iozone3_494.tgz && \
+    curl -o /tmp/iozone.tar http://www.iozone.org/src/current/iozone3_506.tar && \
     cd /tmp && \
-    tar -xzf /tmp/iozone.tar && \
+    tar -xf /tmp/iozone.tar && \
     cd /tmp/iozone*/src/current && \
     make clean && \
     make linux-AMD64
 
 FROM alpine
 LABEL maintainer="1101010@gmail.com" \
-    izone_version="3.494"
+    izone_version="3.506"
 
 RUN adduser -S -u 11010 iozone && \
     mkdir /data && \
     chmod 777 /data
 
-COPY --from=build /tmp/iozone3_494/src/current/iozone /usr/bin/iozone
+COPY --from=build /tmp/iozone3_506/src/current/iozone /usr/bin/iozone
 
 WORKDIR /data
 USER 11010

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * based on [acrelle/iozone](https://github.com/acrelle/iozone-docker) but modified to:
   * run as non-root
   * use multistage build so compilers, etc. are not in the runtime
-  * use latest iozone (currently 3.494)
+  * use latest iozone (currently 3.506)
 
 Available on Dockerhub as 1101010/iozone
 


### PR DESCRIPTION
update to new version and adjust slightly to account for upstream package moving from tgz to tar