### PR TITLE
do not use a very high uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ FROM alpine
 LABEL maintainer="1101010@gmail.com" \
     izone_version="3.506"
 
-RUN adduser -S -u 11010 iozone && \
+RUN adduser -S -u 1000 iozone && \
     mkdir /data && \
     chmod 777 /data
 
 COPY --from=build /tmp/iozone3_506/src/current/iozone /usr/bin/iozone
 
 WORKDIR /data
-USER 11010
+USER 1000
 
 ENTRYPOINT ["/usr/bin/iozone"]
 CMD ["-e","-I","-a","-s","100M","-r","4k","-i","0","-i","1","-i","2"]


### PR DESCRIPTION
When running containers rootless, one has to allocate subuids for each user. When containers use a high user id, then a lot of uids need to be reserved for that user running docker. I understand the sentiment about currently used uid, just it is somehow wasteful to use a high uid.

https://docs.docker.com/engine/security/rootless/

```sh
$ grep ^$(whoami): /etc/subuid
testuser:231072:65536
```